### PR TITLE
Removed redundant 'ChatGPT' string from messages

### DIFF
--- a/chatgpt.js
+++ b/chatgpt.js
@@ -309,10 +309,11 @@ var chatgpt = {
         const msgs = [];
         chatDivs.forEach((div) => {
             const sender = div.textContent.startsWith('ChatGPTChatGPT') ? 'CHATGPT' : 'USER';
-            const msg = Array.from(div.childNodes).map(node => node.innerText)
+            var msg = Array.from(div.childNodes).map(node => node.innerText)
                 .join('\n\n') // insert double line breaks between paragraphs
                 .replace('Copy code', '');
-            msgs.push(sender + ': ' + msg);
+            if (msg.startsWith('ChatGPT') && sender === 'CHATGPT') msg = msg.replace('ChatGPT', '');
+            msgs.push(sender + ': ' + msg.trim());
         });
 
         // Export as .txt


### PR DESCRIPTION
Before:
![image](https://github.com/kudoai/chatgpt.js/assets/100418457/aa17d80b-4e03-470f-8302-d5a77ba166d2)

After:
![image](https://github.com/kudoai/chatgpt.js/assets/100418457/a18acc18-8738-4faf-9858-af0a5bc9d7f1)