### PR TITLE
Added id param value to the docs

### DIFF
--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -375,7 +375,7 @@ Returns a given account detail as a string.
 
 `detail`: A string representing the account detail that will be returned. Defaults to `email`.
 
-Can be one of the following: `email`, `image`, `name`, `picture`. If it isn't, it will remain the default value.
+Can be one of the following: `email`, `id`, `image`, `name`, `picture`. If it isn't, it will remain the default value.
 
 ```js
 async function doSomething() {


### PR DESCRIPTION
P.S. I'm wondering if we could just return the object itself instead of a single detail

why? because let's say you want to `console.log` 2 account' details, email and image.
I think this
```js
const account = chatgpt.getAccountDetails();
console.log(account.email, account.image);
```
is better than this
```js
console.log(chatgpt.getAccountDetails('email'), chatgpt.getAccountDetails('image'));
```