### PR TITLE
Added custom instructions object and methods

### DIFF
--- a/chatgpt.js
+++ b/chatgpt.js
@@ -24,6 +24,15 @@ const chatgpt = {
 
     instructions: {
         add: function(instruction, target) {
+            const validTargets = ['user', 'chatgpt'];
+
+            if (!target) return console.error('Please provide a valid target!');
+            target = target.toLowerCase();
+
+            if (!validTargets.includes(target)) return console.error(`Invalid target ${target}. Valid targets are ${validTargets}`);
+
+            instruction = `\n\n${instruction}`;
+
             return new Promise((resolve) => {
                 chatgpt.getAccessToken().then(token => {
                     chatgpt.instructions.fetch(token).then(instructionsData => {

--- a/chatgpt.js
+++ b/chatgpt.js
@@ -119,6 +119,33 @@ const chatgpt = {
             }
         },
         turnOn: function() {
+            return new Promise((resolve) => {
+                chatgpt.getAccessToken().then(token => {
+                    chatgpt.instructions.fetch(token).then(instructionsData => {
+                        sendUpdateRequest(token, instructionsData).then(() => resolve());
+                    });
+                });
+            });
+
+            function sendUpdateRequest(token, instructionsData) {
+                return new Promise((resolve, reject) => {
+                    const xhr = new XMLHttpRequest();
+                    xhr.open('POST', endpoints.instructions, true);
+                    xhr.setRequestHeader('Accept-Language', 'en-US');
+                    xhr.setRequestHeader('Content-Type', 'application/json');
+                    xhr.setRequestHeader('Authorization', 'Bearer ' + token);
+                    xhr.onload = () => {
+                        if (xhr.status !== 200) return reject('🤖 chatgpt.js >> Request failed. Cannot enable custom instructions.');
+                        console.info('Custom instructions enabled.');
+                        return resolve();
+                    };
+                    xhr.send(JSON.stringify({
+                        about_user_message: instructionsData.about_user_message,
+                        about_model_message: instructionsData.about_model_message,
+                        enabled: true
+                    }));
+                });
+            }
         },
         turnOff: function() {
         }

--- a/chatgpt.js
+++ b/chatgpt.js
@@ -56,7 +56,7 @@ const chatgpt = {
                     xhr.send(JSON.stringify({
                         about_user_message: `${instructionsData.about_user_message}${target === 'user' ? instruction : ''}`,
                         about_model_message: `${instructionsData.about_model_message}${target === 'chatgpt' ? instruction : ''}`,
-                        enabled: true
+                        enabled: instructionsData.enabled
                     }));
                 });
             }
@@ -93,7 +93,7 @@ const chatgpt = {
                     xhr.send(JSON.stringify({
                         about_user_message: target === 'user' ? '' : instructionsData.about_user_message,
                         about_model_message: target === 'chatgpt' ? '' : instructionsData.about_model_message,
-                        enabled: true
+                        enabled: instructionsData.enabled
                     }));
                 });
             }

--- a/chatgpt.js
+++ b/chatgpt.js
@@ -148,6 +148,33 @@ const chatgpt = {
             }
         },
         turnOff: function() {
+            return new Promise((resolve) => {
+                chatgpt.getAccessToken().then(token => {
+                    chatgpt.instructions.fetch(token).then(instructionsData => {
+                        sendUpdateRequest(token, instructionsData).then(() => resolve());
+                    });
+                });
+            });
+
+            function sendUpdateRequest(token, instructionsData) {
+                return new Promise((resolve, reject) => {
+                    const xhr = new XMLHttpRequest();
+                    xhr.open('POST', endpoints.instructions, true);
+                    xhr.setRequestHeader('Accept-Language', 'en-US');
+                    xhr.setRequestHeader('Content-Type', 'application/json');
+                    xhr.setRequestHeader('Authorization', 'Bearer ' + token);
+                    xhr.onload = () => {
+                        if (xhr.status !== 200) return reject('🤖 chatgpt.js >> Request failed. Cannot disable custom instructions.');
+                        console.info('Custom instructions disabled.');
+                        return resolve();
+                    };
+                    xhr.send(JSON.stringify({
+                        about_user_message: instructionsData.about_user_message,
+                        about_model_message: instructionsData.about_model_message,
+                        enabled: false
+                    }));
+                });
+            }
         }
     },
 

--- a/chatgpt.js
+++ b/chatgpt.js
@@ -36,7 +36,7 @@ const chatgpt = {
 
             return new Promise((resolve) => {
                 chatgpt.getAccessToken().then(token => {
-                    chatgpt.instructions.fetchData(token).then(instructionsData => {
+                    this.fetchData(token).then(instructionsData => {
                         sendAddRequest(token, instructionsData).then(() => resolve());
                     });
                 });
@@ -76,7 +76,7 @@ const chatgpt = {
 
             return new Promise((resolve) => {
                 chatgpt.getAccessToken().then(token => {
-                    chatgpt.instructions.fetchData(token).then(instructionsData => {
+                    this.fetchData(token).then(instructionsData => {
                         sendClearRequest(token, instructionsData).then(() => resolve());
                     });
                 });
@@ -130,7 +130,7 @@ const chatgpt = {
         turnOff: function() {
             return new Promise((resolve) => {
                 chatgpt.getAccessToken().then(token => {
-                    chatgpt.instructions.fetchData(token).then(instructionsData => {
+                    this.fetchData(token).then(instructionsData => {
                         sendUpdateRequest(token, instructionsData).then(() => resolve());
                     });
                 });
@@ -160,7 +160,7 @@ const chatgpt = {
         turnOn: function() {
             return new Promise((resolve) => {
                 chatgpt.getAccessToken().then(token => {
-                    chatgpt.instructions.fetchData(token).then(instructionsData => {
+                    this.fetchData(token).then(instructionsData => {
                         sendUpdateRequest(token, instructionsData).then(() => resolve());
                     });
                 });
@@ -190,10 +190,10 @@ const chatgpt = {
         toggle: function() {
             return new Promise((resolve) => {
                 chatgpt.getAccessToken().then(token => {
-                    chatgpt.instructions.fetchData(token).then(instructionsData => {
+                    this.fetchData(token).then(instructionsData => {
                         instructionsData.enabled ? // Are custom instructions enabled?
-                            chatgpt.instructions.turnOff().then(resolve()) : // YES: disable them
-                            chatgpt.instructions.turnOn().then(resolve()); // NO: enable them
+                            this.turnOff().then(resolve()) : // YES: disable them
+                            this.turnOn().then(resolve()); // NO: enable them
                     });
                 });
             });

--- a/chatgpt.js
+++ b/chatgpt.js
@@ -118,35 +118,6 @@ const chatgpt = {
                 });
             }
         },
-        turnOn: function() {
-            return new Promise((resolve) => {
-                chatgpt.getAccessToken().then(token => {
-                    chatgpt.instructions.fetch(token).then(instructionsData => {
-                        sendUpdateRequest(token, instructionsData).then(() => resolve());
-                    });
-                });
-            });
-
-            function sendUpdateRequest(token, instructionsData) {
-                return new Promise((resolve, reject) => {
-                    const xhr = new XMLHttpRequest();
-                    xhr.open('POST', endpoints.instructions, true);
-                    xhr.setRequestHeader('Accept-Language', 'en-US');
-                    xhr.setRequestHeader('Content-Type', 'application/json');
-                    xhr.setRequestHeader('Authorization', 'Bearer ' + token);
-                    xhr.onload = () => {
-                        if (xhr.status !== 200) return reject('🤖 chatgpt.js >> Request failed. Cannot enable custom instructions.');
-                        console.info('Custom instructions enabled.');
-                        return resolve();
-                    };
-                    xhr.send(JSON.stringify({
-                        about_user_message: instructionsData.about_user_message,
-                        about_model_message: instructionsData.about_model_message,
-                        enabled: true
-                    }));
-                });
-            }
-        },
         turnOff: function() {
             return new Promise((resolve) => {
                 chatgpt.getAccessToken().then(token => {
@@ -172,6 +143,35 @@ const chatgpt = {
                         about_user_message: instructionsData.about_user_message,
                         about_model_message: instructionsData.about_model_message,
                         enabled: false
+                    }));
+                });
+            }
+        },
+        turnOn: function() {
+            return new Promise((resolve) => {
+                chatgpt.getAccessToken().then(token => {
+                    chatgpt.instructions.fetch(token).then(instructionsData => {
+                        sendUpdateRequest(token, instructionsData).then(() => resolve());
+                    });
+                });
+            });
+
+            function sendUpdateRequest(token, instructionsData) {
+                return new Promise((resolve, reject) => {
+                    const xhr = new XMLHttpRequest();
+                    xhr.open('POST', endpoints.instructions, true);
+                    xhr.setRequestHeader('Accept-Language', 'en-US');
+                    xhr.setRequestHeader('Content-Type', 'application/json');
+                    xhr.setRequestHeader('Authorization', 'Bearer ' + token);
+                    xhr.onload = () => {
+                        if (xhr.status !== 200) return reject('🤖 chatgpt.js >> Request failed. Cannot enable custom instructions.');
+                        console.info('Custom instructions enabled.');
+                        return resolve();
+                    };
+                    xhr.send(JSON.stringify({
+                        about_user_message: instructionsData.about_user_message,
+                        about_model_message: instructionsData.about_model_message,
+                        enabled: true
                     }));
                 });
             }

--- a/chatgpt.js
+++ b/chatgpt.js
@@ -26,6 +26,33 @@ const chatgpt = {
         add: function(instruction, target) {
         },
         clear: function(target) {
+            return new Promise((resolve) => {
+                chatgpt.getAccessToken().then(token => {
+                    chatgpt.instructions.fetch(token).then(instructionsData => {
+                        sendClearRequest(token, instructionsData).then(() => resolve());
+                    });
+                });
+            });
+
+            function sendClearRequest(token, instructionsData) {
+                return new Promise((resolve, reject) => {
+                    const xhr = new XMLHttpRequest();
+                    xhr.open('POST', endpoints.instructions, true);
+                    xhr.setRequestHeader('Accept-Language', 'en-US');
+                    xhr.setRequestHeader('Content-Type', 'application/json');
+                    xhr.setRequestHeader('Authorization', 'Bearer ' + token);
+                    xhr.onload = () => {
+                        if (xhr.status !== 200) return reject('🤖 chatgpt.js >> Request failed. Cannot clear custom instructions.');
+                        console.info('Custom instructions cleared.');
+                        return resolve();
+                    };
+                    xhr.send(JSON.stringify({
+                        about_user_message: target === 'user' ? '' : instructionsData.about_user_message,
+                        about_model_message: target === 'chatgpt' ? '' : instructionsData.about_model_message,
+                        enabled: true
+                    }));
+                });
+            }
         },
         fetch: function() {
             return new Promise((resolve) => {

--- a/chatgpt.js
+++ b/chatgpt.js
@@ -8,7 +8,8 @@ const endpoints = {
     chats: 'https://chat.openai.com/backend-api/conversations',
     chat: 'https://chat.openai.com/backend-api/conversation',
     share_create: 'https://chat.openai.com/backend-api/share/create',
-    share: 'https://chat.openai.com/backend-api/share'
+    share: 'https://chat.openai.com/backend-api/share',
+    instructions: 'https://chat.openai.com/backend-api/user_system_messages'
 };
 
 // Init queues for feedback methods
@@ -20,6 +21,17 @@ localStorage.notifyQueue = JSON.stringify(notifyQueue);
 // Define chatgpt.methods
 const chatgpt = {
     openAIaccessToken: {},
+
+    instructions: {
+        add: function(instruction, target) {
+        },
+        clear: function(target) {
+        },
+        fetch: function() {
+        },
+        turnOn: function() {},
+        turnOff: function() {}
+    },
 
     actAs: function(persona) {
     // Prompts ChatGPT to act as a persona from https://github.com/KudoAI/chat-prompts/blob/main/personas.json

--- a/chatgpt.js
+++ b/chatgpt.js
@@ -28,6 +28,25 @@ const chatgpt = {
         clear: function(target) {
         },
         fetch: function() {
+            return new Promise((resolve) => {
+                chatgpt.getAccessToken().then(token => {
+                    sendFetchRequest(token).then(instructions => resolve(instructions));
+                });
+            });
+
+            function sendFetchRequest(token) {
+                return new Promise((resolve, reject) => {
+                    const xhr = new XMLHttpRequest();
+                    xhr.open('GET', endpoints.instructions, true);
+                    xhr.setRequestHeader('Accept-Language', 'en-US');
+                    xhr.setRequestHeader('Authorization', 'Bearer ' + token);
+                    xhr.onload = () => {
+                        if (xhr.status !== 200) return reject('🤖 chatgpt.js >> Request failed. Cannot fetch custom instructions.');
+                        return resolve(JSON.parse(xhr.responseText));
+                    };
+                    xhr.send();
+                });
+            }
         },
         turnOn: function() {},
         turnOff: function() {}

--- a/chatgpt.js
+++ b/chatgpt.js
@@ -24,6 +24,33 @@ const chatgpt = {
 
     instructions: {
         add: function(instruction, target) {
+            return new Promise((resolve) => {
+                chatgpt.getAccessToken().then(token => {
+                    chatgpt.instructions.fetch(token).then(instructionsData => {
+                        sendClearRequest(token, instructionsData).then(() => resolve());
+                    });
+                });
+            });
+
+            function sendClearRequest(token, instructionsData) {
+                return new Promise((resolve, reject) => {
+                    const xhr = new XMLHttpRequest();
+                    xhr.open('POST', endpoints.instructions, true);
+                    xhr.setRequestHeader('Accept-Language', 'en-US');
+                    xhr.setRequestHeader('Content-Type', 'application/json');
+                    xhr.setRequestHeader('Authorization', 'Bearer ' + token);
+                    xhr.onload = () => {
+                        if (xhr.status !== 200) return reject('🤖 chatgpt.js >> Request failed. Cannot add custom instruction.');
+                        console.info('Custom instruction added.');
+                        return resolve();
+                    };
+                    xhr.send(JSON.stringify({
+                        about_user_message: `${instructionsData.about_user_message}${target === 'user' ? instruction : ''}`,
+                        about_model_message: `${instructionsData.about_model_message}${target === 'chatgpt' ? instruction : ''}`,
+                        enabled: true
+                    }));
+                });
+            }
         },
         clear: function(target) {
             const validTargets = ['user', 'chatgpt'];

--- a/chatgpt.js
+++ b/chatgpt.js
@@ -26,6 +26,13 @@ const chatgpt = {
         add: function(instruction, target) {
         },
         clear: function(target) {
+            const validTargets = ['user', 'chatgpt'];
+
+            if (!target) return console.error('Please provide a valid target!');
+            target = target.toLowerCase();
+
+            if (!validTargets.includes(target)) return console.error(`Invalid target ${target}. Valid targets are ${validTargets}`);
+
             return new Promise((resolve) => {
                 chatgpt.getAccessToken().then(token => {
                     chatgpt.instructions.fetch(token).then(instructionsData => {

--- a/chatgpt.js
+++ b/chatgpt.js
@@ -61,6 +61,7 @@ const chatgpt = {
                 });
             }
         },
+
         clear: function(target) {
             const validTargets = ['user', 'chatgpt'];
 
@@ -97,6 +98,7 @@ const chatgpt = {
                 });
             }
         },
+
         fetch: function() {
             return new Promise((resolve) => {
                 chatgpt.getAccessToken().then(token => {
@@ -118,6 +120,7 @@ const chatgpt = {
                 });
             }
         },
+
         turnOff: function() {
             return new Promise((resolve) => {
                 chatgpt.getAccessToken().then(token => {
@@ -147,6 +150,7 @@ const chatgpt = {
                 });
             }
         },
+
         turnOn: function() {
             return new Promise((resolve) => {
                 chatgpt.getAccessToken().then(token => {

--- a/chatgpt.js
+++ b/chatgpt.js
@@ -179,6 +179,18 @@ const chatgpt = {
                     }));
                 });
             }
+        },
+
+        toggle: function() {
+            return new Promise((resolve) => {
+                chatgpt.getAccessToken().then(token => {
+                    chatgpt.instructions.fetchData(token).then(instructionsData => {
+                        instructionsData.enabled ?
+                            chatgpt.instructions.turnOff().then(resolve())
+                            : chatgpt.instructions.turnOn().then(resolve());
+                    });
+                });
+            });
         }
     },
 

--- a/chatgpt.js
+++ b/chatgpt.js
@@ -189,15 +189,11 @@ const chatgpt = {
 
         toggle: function() {
             return new Promise((resolve) => {
-                chatgpt.getAccessToken().then(token => {
-                    this.fetchData(token).then(instructionsData => {
-                        instructionsData.enabled ? // Are custom instructions enabled?
-                            this.turnOff().then(resolve()) : // YES: disable them
-                            this.turnOn().then(resolve()); // NO: enable them
-                    });
-                });
-            });
-        }
+                chatgpt.getAccessToken().then(async token => {
+                    const instructionsData = await this.fetchData(token);
+                    await (instructionsData.enabled ? this.turnOff() : this.turnOn());
+                    return resolve();
+        });});}
     },
 
     actAs: function(persona) {

--- a/chatgpt.js
+++ b/chatgpt.js
@@ -35,7 +35,7 @@ const chatgpt = {
 
             return new Promise((resolve) => {
                 chatgpt.getAccessToken().then(token => {
-                    chatgpt.instructions.fetch(token).then(instructionsData => {
+                    chatgpt.instructions.fetchData(token).then(instructionsData => {
                         sendAddRequest(token, instructionsData).then(() => resolve());
                     });
                 });
@@ -72,7 +72,7 @@ const chatgpt = {
 
             return new Promise((resolve) => {
                 chatgpt.getAccessToken().then(token => {
-                    chatgpt.instructions.fetch(token).then(instructionsData => {
+                    chatgpt.instructions.fetchData(token).then(instructionsData => {
                         sendClearRequest(token, instructionsData).then(() => resolve());
                     });
                 });
@@ -99,7 +99,7 @@ const chatgpt = {
             }
         },
 
-        fetch: function() {
+        fetchData: function() {
             return new Promise((resolve) => {
                 chatgpt.getAccessToken().then(token => {
                     sendFetchRequest(token).then(instructionsData => resolve(instructionsData));
@@ -124,7 +124,7 @@ const chatgpt = {
         turnOff: function() {
             return new Promise((resolve) => {
                 chatgpt.getAccessToken().then(token => {
-                    chatgpt.instructions.fetch(token).then(instructionsData => {
+                    chatgpt.instructions.fetchData(token).then(instructionsData => {
                         sendUpdateRequest(token, instructionsData).then(() => resolve());
                     });
                 });
@@ -154,7 +154,7 @@ const chatgpt = {
         turnOn: function() {
             return new Promise((resolve) => {
                 chatgpt.getAccessToken().then(token => {
-                    chatgpt.instructions.fetch(token).then(instructionsData => {
+                    chatgpt.instructions.fetchData(token).then(instructionsData => {
                         sendUpdateRequest(token, instructionsData).then(() => resolve());
                     });
                 });

--- a/chatgpt.js
+++ b/chatgpt.js
@@ -24,14 +24,15 @@ const chatgpt = {
 
     instructions: {
         add: function(instruction, target) {
-            const validTargets = ['user', 'chatgpt'];
+            const validTargets = ['user', 'chatgpt']; // Valid targets
 
             if (!target) return console.error('Please provide a valid target!');
-            target = target.toLowerCase();
+            target = target.toLowerCase(); // Lowercase target
 
-            if (!validTargets.includes(target)) return console.error(`Invalid target ${target}. Valid targets are ${validTargets}`);
+            if (!validTargets.includes(target))
+                return console.error(`Invalid target ${target}. Valid targets are ${validTargets}`);
 
-            instruction = `\n\n${instruction}`;
+            instruction = `\n\n${instruction}`; // Add 2 newlines to the new instruction
 
             return new Promise((resolve) => {
                 chatgpt.getAccessToken().then(token => {
@@ -54,21 +55,24 @@ const chatgpt = {
                         return resolve();
                     };
                     xhr.send(JSON.stringify({
+                        // Previous user instructions + new instruction if the target is 'user'
                         about_user_message: `${instructionsData.about_user_message}${target === 'user' ? instruction : ''}`,
+                        // Previous chatgpt instructions + new instruction if the target is 'chatgpt'
                         about_model_message: `${instructionsData.about_model_message}${target === 'chatgpt' ? instruction : ''}`,
-                        enabled: instructionsData.enabled
+                        enabled: instructionsData.enabled // Keep the previous 'enabled' value
                     }));
                 });
             }
         },
 
         clear: function(target) {
-            const validTargets = ['user', 'chatgpt'];
+            const validTargets = ['user', 'chatgpt']; // Valid targets
 
             if (!target) return console.error('Please provide a valid target!');
-            target = target.toLowerCase();
+            target = target.toLowerCase(); // Lowercase target
 
-            if (!validTargets.includes(target)) return console.error(`Invalid target ${target}. Valid targets are ${validTargets}`);
+            if (!validTargets.includes(target))
+                return console.error(`Invalid target ${target}. Valid targets are ${validTargets}`);
 
             return new Promise((resolve) => {
                 chatgpt.getAccessToken().then(token => {
@@ -91,9 +95,11 @@ const chatgpt = {
                         return resolve();
                     };
                     xhr.send(JSON.stringify({
+                        // Send empty string to clear the user instructions if the target is 'user', else send previous instructions
                         about_user_message: target === 'user' ? '' : instructionsData.about_user_message,
+                        // Send empty string to clear the chatgpt instructions if the target is 'chatgpt', else send previous instructions
                         about_model_message: target === 'chatgpt' ? '' : instructionsData.about_model_message,
-                        enabled: instructionsData.enabled
+                        enabled: instructionsData.enabled // Keep the previous 'enabled' value
                     }));
                 });
             }
@@ -114,7 +120,7 @@ const chatgpt = {
                     xhr.setRequestHeader('Authorization', 'Bearer ' + token);
                     xhr.onload = () => {
                         if (xhr.status !== 200) return reject('🤖 chatgpt.js >> Request failed. Cannot fetch custom instructions.');
-                        return resolve(JSON.parse(xhr.responseText));
+                        return resolve(JSON.parse(xhr.responseText)); // Return the response JSON
                     };
                     xhr.send();
                 });
@@ -143,9 +149,9 @@ const chatgpt = {
                         return resolve();
                     };
                     xhr.send(JSON.stringify({
-                        about_user_message: instructionsData.about_user_message,
-                        about_model_message: instructionsData.about_model_message,
-                        enabled: false
+                        about_user_message: instructionsData.about_user_message, // Keep the previous value
+                        about_model_message: instructionsData.about_model_message, // Keep the previous value
+                        enabled: false // Set 'enabled' to false to disable custom instructions
                     }));
                 });
             }
@@ -173,9 +179,9 @@ const chatgpt = {
                         return resolve();
                     };
                     xhr.send(JSON.stringify({
-                        about_user_message: instructionsData.about_user_message,
-                        about_model_message: instructionsData.about_model_message,
-                        enabled: true
+                        about_user_message: instructionsData.about_user_message, // Keep the previous 'enabled' value
+                        about_model_message: instructionsData.about_model_message, // Keep the previous 'enabled' value
+                        enabled: true // Set 'enabled' to true to enable custom instructions
                     }));
                 });
             }
@@ -185,9 +191,9 @@ const chatgpt = {
             return new Promise((resolve) => {
                 chatgpt.getAccessToken().then(token => {
                     chatgpt.instructions.fetchData(token).then(instructionsData => {
-                        instructionsData.enabled ?
-                            chatgpt.instructions.turnOff().then(resolve())
-                            : chatgpt.instructions.turnOn().then(resolve());
+                        instructionsData.enabled ? // Are custom instructions enabled?
+                            chatgpt.instructions.turnOff().then(resolve()) : // YES: disable them
+                            chatgpt.instructions.turnOn().then(resolve()); // NO: enable them
                     });
                 });
             });

--- a/chatgpt.js
+++ b/chatgpt.js
@@ -36,12 +36,12 @@ const chatgpt = {
             return new Promise((resolve) => {
                 chatgpt.getAccessToken().then(token => {
                     chatgpt.instructions.fetch(token).then(instructionsData => {
-                        sendClearRequest(token, instructionsData).then(() => resolve());
+                        sendAddRequest(token, instructionsData).then(() => resolve());
                     });
                 });
             });
 
-            function sendClearRequest(token, instructionsData) {
+            function sendAddRequest(token, instructionsData) {
                 return new Promise((resolve, reject) => {
                     const xhr = new XMLHttpRequest();
                     xhr.open('POST', endpoints.instructions, true);

--- a/chatgpt.js
+++ b/chatgpt.js
@@ -100,7 +100,7 @@ const chatgpt = {
         fetch: function() {
             return new Promise((resolve) => {
                 chatgpt.getAccessToken().then(token => {
-                    sendFetchRequest(token).then(instructions => resolve(instructions));
+                    sendFetchRequest(token).then(instructionsData => resolve(instructionsData));
                 });
             });
 
@@ -118,8 +118,10 @@ const chatgpt = {
                 });
             }
         },
-        turnOn: function() {},
-        turnOff: function() {}
+        turnOn: function() {
+        },
+        turnOff: function() {
+        }
     },
 
     actAs: function(persona) {


### PR DESCRIPTION
to avoid the repetition of `.then()` in `toggle` the following code can be used
```js
        toggle: function() {
            return new Promise((resolve) => {
                chatgpt.getAccessToken().then(async token => {
                    const instructionsData = await this.fetchData(token);
                    await (instructionsData.enabled
                        ? this.turnOff()
                        : this.turnOn());
                    return resolve();
                });
            });
        }
```
but I cannot test it because the website is currently down
![image](https://github.com/KudoAI/chatgpt.js/assets/100418457/099d0c2d-4f04-4011-8da0-79f9ead8229b)