### PR TITLE
Update chatgpt.js to play nice with custom GPTs

### DIFF
--- a/chatgpt.js
+++ b/chatgpt.js
@@ -852,7 +852,17 @@ const chatgpt = {
                                 }
                             }
                             sub.sort((a, b) => a.create_time - b.create_time); // sort in chronological order
-                            sub = sub.map((x) => x.content.parts[0]); // pull out the messages after sorting
+                            // pull out the messages after sorting
+                            sub = sub.map((x) => { 
+                                switch(x.content.content_type) {
+                                    case 'code':
+                                        return x.content.text;
+                                    case 'text':
+                                        return x.content.parts[0];
+                                    default:
+                                        return;
+                                }
+                            });
                             sub = sub.length === 1 ? sub[0] : sub; // convert not regenerated responses to strings
                             chatGPTMessages.push(sub); // array of arrays (length > 1 = regenerated responses)
                         }


### PR DESCRIPTION
Presently custom GPT have 2 types of content types (that I know of); code and text. This is causing the lib to crash while trying to use it. This patch aims to fix this issue by accounting for the same.