### PR TITLE
fix: use native uuid generator when possible

### DIFF
--- a/chatgpt.js
+++ b/chatgpt.js
@@ -1872,14 +1872,19 @@ const chatgpt = { // eslint-disable-line no-redeclare
     unminify() { chatgpt.code.unminify(); },
 
     uuidv4() {
-        let d = new Date().getTime(); // get current timestamp in ms (to ensure UUID uniqueness)
-        const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-            const r = ( // generate random nibble
-                ( d + (window.crypto.getRandomValues(new Uint32Array(1))[0] / (Math.pow(2, 32) - 1))*16)%16 | 0 );
-            d = Math.floor(d/16); // correspond each UUID digit to unique 4-bit chunks of timestamp
-            return ( c == 'x' ? r : (r&0x3|0x8) ).toString(16); // generate random hexadecimal digit
-        });
-        return uuid;
+        try {
+            // use native secure uuid generator when available
+            return crypto.randomUUID();
+        } catch(_e) {
+            let d = new Date().getTime(); // get current timestamp in ms (to ensure UUID uniqueness)
+            const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+                const r = ( // generate random nibble
+                    ( d + (window.crypto.getRandomValues(new Uint32Array(1))[0] / (Math.pow(2, 32) - 1))*16)%16 | 0 );
+                d = Math.floor(d/16); // correspond each UUID digit to unique 4-bit chunks of timestamp
+                return ( c == 'x' ? r : (r&0x3|0x8) ).toString(16); // generate random hexadecimal digit
+            });
+            return uuid;
+        }
     },
 
     writeCode() { chatgpt.code.write(); }


### PR DESCRIPTION
This PR updates `uuidv4` to use native secure uuid generator when possible. This method works on server side js runtimes as well as browsers. IT falls back to the default behavior when secure uuid generator is not available.