### PR TITLE
Add history.deleteChat()

### DIFF
--- a/chatgpt.d.ts
+++ b/chatgpt.d.ts
@@ -173,6 +173,7 @@ declare interface ChatGPT {
   hideHeader(): void
 
   history: {
+    deleteChat(chatToDelete?: string | number): Promise<boolean>
     isLoaded(timeout?: number | null): Promise<boolean>
   }
 

--- a/docs/USERGUIDE.md
+++ b/docs/USERGUIDE.md
@@ -1730,6 +1730,25 @@ API related to the chat history.
 
 #
 
+#### `deleteChat()` `async`
+
+Deletes a chat from ChatGPT history.
+
+Parameters:
+
+`chatToDelete` (optional): A string or integer representing the chat to delete. Can be `'active'`, `'latest'`, the index of a chat, the title of a chat or the ID of a chat. Defaults to `'active'`.
+
+Example:
+
+```js
+(async () => {
+    await chatgpt.history.deleteChat('active')
+    chatgpt.alert('Chat deleted.')
+})()
+```
+
+#
+
 #### `isLoaded()` `async`
 
 Resolves a promise when chat history has finished loading.

--- a/src/chatgpt.js
+++ b/src/chatgpt.js
@@ -999,6 +999,25 @@ const chatgpt = {
     hideHeader() { chatgpt.header.hide() },
 
     history: {
+        deleteChat(chatToDelete = 'active') {
+            return new Promise((resolve, reject) =>
+                chatgpt.getAccessToken().then(token =>
+                    chatgpt.getChatData(chatToDelete, 'id').then(chat => {
+                        const xhr = new XMLHttpRequest()
+                        xhr.open('PATCH', `${chatgpt.endpoints.openai.chat}/${chat.id}`, true)
+                        xhr.setRequestHeader('Content-Type', 'application/json')
+                        xhr.setRequestHeader('Authorization', 'Bearer ' + token)
+                        xhr.onload = () => {
+                            if (xhr.status != 200)
+                                return reject('Request failed. Cannot delete chat.')
+                            return resolve(true)
+                        }
+                        xhr.send(JSON.stringify({ is_visible: false }))
+                    }).catch(reject)
+                ).catch(reject)
+            )
+        },
+
         async isLoaded(timeout = null) {
             const timeoutPromise = timeout ? new Promise(resolve => setTimeout(() => resolve(false), timeout)) : null
             const isLoadedPromise = new Promise(resolve => {


### PR DESCRIPTION
## Summary
- Add chatgpt.history.deleteChat() for deleting chats from history
- Resolve chat targets using existing getChatData() support for active/latest/index/title/id
- Add TypeScript definition and USERGUIDE docs

Fixes #528

## Test
- npm run lint