### PR TITLE
Add code.debug()

### DIFF
--- a/chatgpt.d.ts
+++ b/chatgpt.d.ts
@@ -92,6 +92,7 @@ declare interface ChatGPT {
   clearChats(): Promise<void>
 
   code: {
+    debug(code: string): Promise<string>
     execute(code: string): Promise<string>
     extract(msg?: string): string
     isIdle(timeout?: number | null): Promise<boolean>

--- a/docs/USERGUIDE.md
+++ b/docs/USERGUIDE.md
@@ -188,7 +188,7 @@ export default {
 - [Library APIs](#library-apis)
   - [`autoRefresh`](#autorefresh-api): [`activate()`](#activate), [`deactivate()`](#deactivate), [`nowTimeStamp()`](#nowtimestamp)
   - [`browser`](#browser-api): [`isLightMode()`](#islightmode-1), [`isDarkMode()`](#isdarkmode-1), [`isChromium()`](#ischromium), [`isChrome()`](#ischrome), [`isEdge()`](#isedge), [`isBrave()`](#isbrave), [`isFirefox()`](#isfirefox), [`isFullScreen()`](#isfullscreen), [`isMobile()`](#ismobile)
-  - [`code`](#code-api): [`minify()`](#minify-async), [`execute()`](#execute-async), [`extract()`](#extract), [`isIdle()`](#isidle-async-1), [`obfuscate()`](#obfuscate-async), [`refactor()`](#refactor-async), [`review()`](#review-async), [`unminify()`](#unminify-async), [`write()`](#write-async)
+  - [`code`](#code-api): [`debug()`](#debug-async), [`minify()`](#minify-async), [`execute()`](#execute-async), [`extract()`](#extract), [`isIdle()`](#isidle-async-1), [`obfuscate()`](#obfuscate-async), [`refactor()`](#refactor-async), [`review()`](#review-async), [`unminify()`](#unminify-async), [`write()`](#write-async)
   - [`footer`](#footer-api): [`get()`](#get), [`hide()`](#hide), [`show()`](#show)
   - [`header`](#header-api): [`get()`](#get-1), [`hide()`](#hide-1), [`show()`](#show-1)
   - [`history`](#history-api): [`isLoaded()`](#isloaded-async-1)
@@ -1524,6 +1524,33 @@ if (chatgpt.browser.isMobile()) {
 <a href="#top">Back to top ↑</a>
 
 ## code `api`
+
+#### `debug()` `async`
+
+Asks ChatGPT to debug the given code and return corrected code.
+
+Parameters:
+
+`code`: A string being the code to debug.
+
+Example:
+
+```js
+(async () => {
+    const debuggedCode = await chatgpt.code.debug(`
+        function add(a, b) {
+            return a - b
+        }`)
+    chatgpt.alert(debuggedCode)
+
+    /* Alerts:
+    function add(a, b) {
+        return a + b
+    } */
+})()
+```
+
+#
 
 #### `minify()` `async`
 

--- a/src/chatgpt.js
+++ b/src/chatgpt.js
@@ -510,6 +510,19 @@ const chatgpt = {
     code: {
     // Tip: Use template literals for easier passing of code arguments. Ensure backticks and `$`s are escaped (using `\`)
 
+        async debug(code) {
+            if (!chatgpt._validateArg({ arg: code, type: 'string' })) return
+            console.info('Debugging code...')
+            const prompt = `Debug the following code and return the corrected code:\n\n${code}`
+            let resp
+            if (chatgpt.env == 'frontend') {
+                chatgpt.send(prompt) ; await chatgpt.chatgpt.isIdle()
+                resp = await chatgpt.getChatData('active', 'msg', 'chatgpt', 'latest')
+            } else
+                resp = await chatgpt.send(prompt)
+            return chatgpt.code.extract(resp)
+        },
+
         async execute(code) {
             if (!chatgpt._validateArg({ arg: code, type: 'string' })) return
             console.info('Executing code...')


### PR DESCRIPTION
## Summary

- Add `chatgpt.code.debug(code)` using the existing code helper flow
- Expose the new helper in `chatgpt.d.ts`
- Document `code.debug()` in the user guide API list and code API section

## Verification

- `npm run lint`

Fixes #602