### PR TITLE
Add CLI summarize file option

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,12 @@ Use `--provider google` to use Google AI instead of the default OpenRouter provi
 chatgpt --provider google --query "Write a one-line git commit message"
 ```
 
+Summarize a local text file:
+
+```bash
+chatgpt --summarize ./notes.txt
+```
+
 To view all CLI options or create a local config file:
 
 ```bash

--- a/assets/data/_locales/en/messages.json
+++ b/assets/data/_locales/en/messages.json
@@ -41,6 +41,7 @@
   "helpSection_flags": { "message": "Config options" },
   "helpSection_cmds": { "message": "Commands" },
   "optionDesc_query": { "message": "Query to send AI" },
+  "optionDesc_summarize": { "message": "Summarize a file" },
   "optionDesc_uiLang": { "message": "ISO 639-1 code of language to display UI in" },
   "optionDesc_config": { "message": "Load custom config file" },
   "optionDesc_quiet": { "message": "Suppress all logging except errors" },

--- a/docs/README.md
+++ b/docs/README.md
@@ -227,6 +227,12 @@ Use `--provider google` to use Google AI instead of the default OpenRouter provi
 chatgpt --provider google --query "Write a one-line git commit message"
 ```
 
+Summarize a local text file:
+
+```bash
+chatgpt --summarize ./notes.txt
+```
+
 To view all CLI options or create a local config file:
 
 ```bash

--- a/docs/USERGUIDE.md
+++ b/docs/USERGUIDE.md
@@ -81,6 +81,7 @@ chatgpt  # or cjs
 ```
 Parameter options:
  --q, --query "msg"          Query to send AI.
+ --summarize="path/to/file"  Summarize a file.
  --ui-lang="code"            ISO 639-1 code of language to display UI in.
  --config="path/to/file"     Load custom config file.
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -9,7 +9,8 @@
 
     // Import LIBS
     globalThis.log = require('./lib/log')
-    const chatgpt = require(`../chatgpt${ env.modes.dev ? '' : '.min' }.js`),
+    const fs = require('fs'),
+          chatgpt = require(`../chatgpt${ env.modes.dev ? '' : '.min' }.js`),
           loader = require('./lib/loader').create({ width: env.width })
 
     await init.cli()
@@ -27,6 +28,8 @@
     // Get AI reply
     loader.start()
     const query = cli.config.joke ? 'Tell me a joke and make it funny.'
+                : cli.config.summarize ? `Summarize the following file:\n\n${
+                    fs.readFileSync(cli.config.summarize, 'utf8') }`
                 : cli.config.query
     try {
         await chatgpt.send(query, {

--- a/src/cli/lib/log.js
+++ b/src/cli/lib/log.js
@@ -65,6 +65,7 @@ module.exports = {
             params: [
                 `\n${this.colors.bw}o ${cli.msgs.helpSection_params}:${this.colors.nc}`,
                 ` -q, --query "msg"           ${cli.msgs.optionDesc_query}.`,
+                ` --summarize="path/to/file"  ${cli.msgs.optionDesc_summarize || 'Summarize a file'}.`,
                 ` --ui-lang="code"            ${cli.msgs.optionDesc_uiLang}.`,
                 ` --config="path/to/file"     ${cli.msgs.optionDesc_config}.`
             ],

--- a/src/cli/lib/settings.js
+++ b/src/cli/lib/settings.js
@@ -9,6 +9,7 @@ module.exports = {
     controls: {
         provider: { type: 'param', regex: /^--?p(?:rovider)?$/, defaultVal: 'openrouter' },
         query: { type: 'param', regex: /^--?(?:q|query|ask|send)?$/, defaultVal: 'hi' },
+        summarize: { type: 'param', valType: 'filepath', regex: /^--?summarize(?:[=\s].*|$)/ },
         uiLang: { type: 'param', valType: 'langCode', regex: /^--?ui[-_]?lang(?:[=\s].*|$)/ },
         config: { type: 'param', valType: 'filepath', regex: /^--?config(?:[=\s].*|$)/ },
         quietMode: { type: 'flag', regex: /^--?(?:V|quiet)?(?:[-_]?mode)?$/ },


### PR DESCRIPTION
## Summary

- Add `--summarize="path/to/file"` as a CLI parameter
- Read the target file and send its contents with a summarization prompt
- Update CLI help text, English locale message, and README/user guide examples

## Verification

- `npm run lint`
- `node src/cli/index.js --help`

Fixes #598
