### PR TITLE
Add CLI random answer option

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,12 @@ Use `--provider google` to use Google AI instead of the default OpenRouter provi
 chatgpt --provider google --query "Write a one-line git commit message"
 ```
 
+Ask and answer a random question:
+
+```bash
+chatgpt --random-answer
+```
+
 To view all CLI options or create a local config file:
 
 ```bash

--- a/assets/data/_locales/en/messages.json
+++ b/assets/data/_locales/en/messages.json
@@ -46,6 +46,7 @@
   "optionDesc_quiet": { "message": "Suppress all logging except errors" },
   "optionDesc_init": { "message": "Create config file (in project root)" },
   "optionDesc_joke": { "message": "Tells a funny joke at random" },
+  "optionDesc_randomAnswer": { "message": "Answer a random question" },
   "optionDesc_help": { "message": "Display help screen" },
   "optionDesc_version": { "message": "Show version number" },
   "optionDesc_stats": { "message": "Show npm stats" },

--- a/docs/README.md
+++ b/docs/README.md
@@ -227,6 +227,12 @@ Use `--provider google` to use Google AI instead of the default OpenRouter provi
 chatgpt --provider google --query "Write a one-line git commit message"
 ```
 
+Ask and answer a random question:
+
+```bash
+chatgpt --random-answer
+```
+
 To view all CLI options or create a local config file:
 
 ```bash

--- a/docs/USERGUIDE.md
+++ b/docs/USERGUIDE.md
@@ -90,6 +90,7 @@ Boolean options:
 Commands:
  -i, --init                  Create config file (in project root).
  -j, --joke                  Tells a funny joke at random.
+     --random-answer         Answer a random question.
  -h, --help                  Display help screen.
  -v, --version               Show version number.
      --stats                 Show npm stats.

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -26,7 +26,8 @@
 
     // Get AI reply
     loader.start()
-    const query = cli.config.joke ? 'Tell me a joke and make it funny.'
+    const query = cli.config.randomAnswer ? 'Generate a single random question on any topic, then answer it.'
+                : cli.config.joke ? 'Tell me a joke and make it funny.'
                 : cli.config.query
     try {
         await chatgpt.send(query, {

--- a/src/cli/lib/log.js
+++ b/src/cli/lib/log.js
@@ -76,6 +76,7 @@ module.exports = {
                 `\n${this.colors.bw}o ${cli.msgs.helpSection_cmds}:${this.colors.nc}`,
                 ` -i, --init                  ${cli.msgs.optionDesc_init}.`,
                 ` -j, --joke                  ${cli.msgs.optionDesc_joke}.`,
+                `     --random-answer         ${cli.msgs.optionDesc_randomAnswer || 'Answer a random question'}.`,
                 ` -h, --help                  ${cli.msgs.optionDesc_help}.`,
                 ` -v, --version               ${cli.msgs.optionDesc_version}.`,
                 `     --stats                 ${cli.msgs.optionDesc_stats}.`,

--- a/src/cli/lib/settings.js
+++ b/src/cli/lib/settings.js
@@ -14,6 +14,7 @@ module.exports = {
         quietMode: { type: 'flag', regex: /^--?(?:V|quiet)?(?:[-_]?mode)?$/ },
         init: { type: 'cmd', regex: /^-{0,2}i(?:nit)?$/ },
         joke: { type: 'cmd', regex: /^--?j(?:oke)?$/ },
+        randomAnswer: { type: 'cmd', regex: /^--?random[-_]?answer$/ },
         help: { type: 'cmd', regex: /^--?h(?:elp)?$/ },
         version: { type: 'cmd', regex: /^--?ve?r?s?i?o?n?$/ },
         stats: { type: 'cmd', regex: /^--?stats?$/ }


### PR DESCRIPTION
## Summary

- Add `--random-answer` as a CLI command option
- Send a random-question prompt when the option is used
- Update CLI help text, English locale message, and README/user guide examples

## Verification

- `npm run lint`
- `node src/cli/index.js --help`

Fixes #592
