### PR TITLE
feat(cli): add interactive terminal chat history nav (#673)

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -26,7 +26,64 @@
         chatgpt.setProvider(cli.config.provider, {
             key: process.env[`${cli.config.provider.toUpperCase()}_API_KEY`] })
 
-    // Get AI reply
+    // Check if we should run interactive mode
+    const isInteractive = cli.config.interactive || (!cli.config.joke && !cli.config.randomAnswer && !cli.config.summarize && cli.config.query === 'hi' && !env.args.some(arg => /^-+q/.test(arg)));
+
+    if (isInteractive) {
+        const readline = require('readline'),
+              path = require('path'),
+              os = require('os');
+
+        const historyFile = path.join(os.homedir(), '.chatgpt_history');
+        let history = [];
+        if (fs.existsSync(historyFile)) {
+            history = fs.readFileSync(historyFile, 'utf8').split('\n').filter(Boolean).reverse();
+        }
+
+        const rl = readline.createInterface({
+            input: process.stdin,
+            output: process.stdout,
+            prompt: 'chatgpt> ',
+            historySize: 1000,
+            history: history
+        });
+
+        rl.prompt();
+
+        rl.on('line', async (line) => {
+            const input = line.trim();
+            if (!input) {
+                rl.prompt();
+                return;
+            }
+            if (/^(?:exit|quit)$/i.test(input)) {
+                rl.close();
+                return;
+            }
+
+            loader.start();
+            try {
+                await chatgpt.send(input, {
+                    provider: cli.config.provider,
+                    output: 'stdout',
+                    onLoadStart: () => loader.stop({ clear: false })
+                });
+            } catch (err) {
+                log.error(err.message || err);
+            } finally {
+                loader.stop();
+                console.log(); // Newline before next prompt
+                rl.prompt();
+            }
+        }).on('close', () => {
+            fs.writeFileSync(historyFile, history.slice(0, 1000).reverse().join('\n') + '\n');
+            process.exit(0);
+        });
+
+        return; // Keep process alive for REPL
+    }
+
+    // Get AI reply (one-off mode)
     loader.start()
     const query = cli.config.joke ? 'Tell me a joke and make it funny.'
                 : cli.config.randomAnswer ? 'Generate a single random question on any topic, then answer it.'

--- a/src/cli/lib/settings.js
+++ b/src/cli/lib/settings.js
@@ -7,6 +7,7 @@ module.exports = {
     configFilename: '.chatgpt.config.mjs',
 
     controls: {
+        interactive: { type: 'cmd', regex: /^--?interactive$/ },
         provider: { type: 'param', regex: /^--?p(?:rovider)?$/, defaultVal: 'openrouter' },
         query: { type: 'param', regex: /^--?(?:q|query|ask|send)?$/, defaultVal: 'hi' },
         summarize: { type: 'param', valType: 'filepath', allowText: true, regex: /^--?summarize(?:[=\s].*|$)/ },

--- a/src/cli/lib/settings.js
+++ b/src/cli/lib/settings.js
@@ -1,7 +1,8 @@
 const fs = require('fs'),
       path = require('path')
 
-;(globalThis.cli ??= {}).config = {}
+globalThis.cli ??= {}
+globalThis.cli.config = {}
 
 module.exports = {
     configFilename: '.chatgpt.config.mjs',
@@ -59,9 +60,10 @@ module.exports = {
         if (cli.configPath) // load from config file
             try {
                 const mod = require(cli.configPath), fileConfig = mod?.default ?? mod
-                if (!fileConfig || typeof fileConfig != 'object')
+                if (!fileConfig || typeof fileConfig != 'object') {
                     log.configURLandExit(`${cli.msgs.error_invalidConfigFile}.`)
-                ;(arguments.length ? inputCtrlKeys : Object.keys(fileConfig)).forEach(key => {
+                }
+                (arguments.length ? inputCtrlKeys : Object.keys(fileConfig)).forEach(key => {
                     if (!(key in fileConfig)) return
                     const val = fileConfig[key], ctrl = this.controls[key]
                     if (!ctrl) {


### PR DESCRIPTION
## Description
This PR introduces a continuous interactive REPL mode for the CLI to address the lack of chat history navigation.

**Resolves #673**

## Changes Made
- **Interactive REPL (`src/cli/index.js`)**: Initialized a continuous `readline` prompt (`chatgpt> `) when no explicit query arguments are passed or when using the new `--interactive` flag.
- **Terminal History Navigation**: Configured the `readline` interface to store history, allowing users to press the **Up** and **Down** arrow keys to navigate their previously sent chat queries within the terminal.
- **Persistent History**: Chat history is now automatically saved to and loaded from `~/.chatgpt_history` in the user's home directory. This ensures prompt history is preserved across completely separate CLI sessions.
- **Settings Update (`src/cli/lib/settings.js`)**: Registered the new `--interactive` flag to manually trigger the REPL loop.
